### PR TITLE
Update variable names in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ COPY pom.xml /app/
 RUN mvn dependency:go-offline
 
 # Set default args needed inside the entrypoint
-ARG GIT_REPO_URL="https://github.com/MyCoRe-Org/mycore-website.git"
-ARG HUGO_BASE_URL="https://www.mycore.de"
+ARG MYCORE_WEBSITE_REPO_URL="https://github.com/MyCoRe-Org/mycore-website.git"
+ARG MYCORE_BASE_URL="https://www.mycore.de"
 
 # Set the entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  builder:
+    build: .
+    environment:
+      MYCORE_WEBSITE_REPO_URL: ${MYCORE_WEBSITE_REPO_URL}
+      MYCORE_BASE_URL: ${MYCORE_BASE_URL}
+    volumes:
+      - $PWD/www:/public


### PR DESCRIPTION
Add additional docker-compose.yml, that can be used to run "docker compose up" to build the website. A `.env` file must be used to set the variables. Otherwise they have to be added as cli argument. Copy and paste the following into the .env

```
MYCORE_WEBSITE_REPO_URL=https://github.com/MyCoRe-Org/mycore-website.git
MYCORE_BASE_URL=https://www.mycore.de
```